### PR TITLE
add frequency check for ema update; cleanup/refactor limit checking

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -96,7 +96,7 @@ async function feesTooHigh(transactionArgs: TransactionArgs)  {
 
   const now = Math.floor(Date.now() / 1000);
   const elapsed_secs = now - lastUpdateTime;
-  const doUpdate = (elapsed_secs < EMA_UPDATE_DELTA_SECS);
+  const doUpdate = (elapsed_secs >= EMA_UPDATE_DELTA_SECS);
   const gasPrice = (maxFeePerGas + maxPriorityFeePerGas);
   let rejectTxn = false;
 


### PR DESCRIPTION
- add EMA_UPDATE_DELTA_SECS to control how frequently we update gas/blob price limits
- refactor code to compute elapsed time since last update and update both gas and blob prices
- fix bug always update both gas/blob prices (if required) and do both checks for logging purposes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for managing transaction fees and gas limits for enhanced efficiency.
	- Introduced a new constant to define update frequency for gas limit calculations.

- **Bug Fixes**
	- Enhanced fee rejection logic for clearer and more structured handling of transaction fees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->